### PR TITLE
Fix doctests for python3

### DIFF
--- a/pyrfc3339/generator.py
+++ b/pyrfc3339/generator.py
@@ -9,7 +9,7 @@ def generate(dt, utc=True, accept_naive=False, microseconds=False):
     :class:`datetime.datetime`.
 
     >>> from datetime import datetime
-    >>> generate(datetime(2009,01,01,12,59,59,0,pytz.utc))
+    >>> generate(datetime(2009,1,1,12,59,59,0,pytz.utc))
     '2009-01-01T12:59:59Z'
 
     The timestamp will use UTC unless `utc=False` is specified, in which case
@@ -17,7 +17,7 @@ def generate(dt, utc=True, accept_naive=False, microseconds=False):
     :attr:`tzinfo` parameter.
 
     >>> eastern = pytz.timezone('US/Eastern')
-    >>> dt = eastern.localize(datetime(2009,01,01,12,59,59))
+    >>> dt = eastern.localize(datetime(2009,1,1,12,59,59))
     >>> generate(dt)
     '2009-01-01T17:59:59Z'
     >>> generate(dt, utc=False)
@@ -25,19 +25,19 @@ def generate(dt, utc=True, accept_naive=False, microseconds=False):
 
     Unless `accept_naive=True` is specified, the `datetime` must not be naive.
 
-    >>> generate(datetime(2009,01,01,12,59,59,0))
+    >>> generate(datetime(2009,1,1,12,59,59,0))
     Traceback (most recent call last):
     ...
     ValueError: naive datetime and accept_naive is False
 
-    >>> generate(datetime(2009,01,01,12,59,59,0), accept_naive=True)
+    >>> generate(datetime(2009,1,1,12,59,59,0), accept_naive=True)
     '2009-01-01T12:59:59Z'
 
     If `accept_naive=True` is specified, the `datetime` is assumed to be UTC.
     Attempting to generate a local timestamp from a naive datetime will result
     in an error.
 
-    >>> generate(datetime(2009,01,01,12,59,59,0), accept_naive=True, utc=False)
+    >>> generate(datetime(2009,1,1,12,59,59,0), accept_naive=True, utc=False)
     Traceback (most recent call last):
     ...
     ValueError: cannot generate a local timestamp from a naive datetime


### PR DESCRIPTION
This fixes the following error for python3 here:

```
======================================================================
FAIL: Doctest: pyrfc3339.generator.generate
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib64/python3.3/doctest.py", line 2179, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
nose.proxy.AssertionError: Failed doctest test for pyrfc3339.generator.generate
  File "/var/tmp/portage/dev-python/pyrfc3339-0.2/work/pyRFC3339-0.2/pyrfc3339/generator.py", line 6, in generate

----------------------------------------------------------------------
File "/var/tmp/portage/dev-python/pyrfc3339-0.2/work/pyRFC3339-0.2/pyrfc3339/generator.py", line 12, in pyrfc3339.generator.generate
Failed example:
    generate(datetime(2009,01,01,12,59,59,0,pytz.utc))
Exception raised:
    Traceback (most recent call last):
      File "/usr/lib64/python3.3/doctest.py", line 1313, in __run
        compileflags, 1), test.globs)
      File "<doctest pyrfc3339.generator.generate[1]>", line 1
        generate(datetime(2009,01,01,12,59,59,0,pytz.utc))
                                ^
    SyntaxError: invalid token
----------------------------------------------------------------------
File "/var/tmp/portage/dev-python/pyrfc3339-0.2/work/pyRFC3339-0.2/pyrfc3339/generator.py", line 20, in pyrfc3339.generator.generate
Failed example:
    dt = eastern.localize(datetime(2009,01,01,12,59,59))
Exception raised:
    Traceback (most recent call last):
      File "/usr/lib64/python3.3/doctest.py", line 1313, in __run
        compileflags, 1), test.globs)
      File "<doctest pyrfc3339.generator.generate[3]>", line 1
        dt = eastern.localize(datetime(2009,01,01,12,59,59))
                                             ^
    SyntaxError: invalid token
----------------------------------------------------------------------
File "/var/tmp/portage/dev-python/pyrfc3339-0.2/work/pyRFC3339-0.2/pyrfc3339/generator.py", line 21, in pyrfc3339.generator.generate
Failed example:
    generate(dt)
Exception raised:
    Traceback (most recent call last):
      File "/usr/lib64/python3.3/doctest.py", line 1313, in __run
        compileflags, 1), test.globs)
      File "<doctest pyrfc3339.generator.generate[4]>", line 1, in <module>
        generate(dt)
    NameError: name 'dt' is not defined
----------------------------------------------------------------------
File "/var/tmp/portage/dev-python/pyrfc3339-0.2/work/pyRFC3339-0.2/pyrfc3339/generator.py", line 23, in pyrfc3339.generator.generate
Failed example:
    generate(dt, utc=False)
Exception raised:
    Traceback (most recent call last):
      File "/usr/lib64/python3.3/doctest.py", line 1313, in __run
        compileflags, 1), test.globs)
      File "<doctest pyrfc3339.generator.generate[5]>", line 1, in <module>
        generate(dt, utc=False)
    NameError: name 'dt' is not defined
----------------------------------------------------------------------
File "/var/tmp/portage/dev-python/pyrfc3339-0.2/work/pyRFC3339-0.2/pyrfc3339/generator.py", line 28, in pyrfc3339.generator.generate
Failed example:
    generate(datetime(2009,01,01,12,59,59,0))
Expected:
    Traceback (most recent call last):
    ...
    ValueError: naive datetime and accept_naive is False
Got:
    Traceback (most recent call last):
      File "/usr/lib64/python3.3/doctest.py", line 1313, in __run
        compileflags, 1), test.globs)
      File "<doctest pyrfc3339.generator.generate[6]>", line 1
        generate(datetime(2009,01,01,12,59,59,0))
                                ^
    SyntaxError: invalid token
----------------------------------------------------------------------
File "/var/tmp/portage/dev-python/pyrfc3339-0.2/work/pyRFC3339-0.2/pyrfc3339/generator.py", line 33, in pyrfc3339.generator.generate
Failed example:
    generate(datetime(2009,01,01,12,59,59,0), accept_naive=True)
Exception raised:
    Traceback (most recent call last):
      File "/usr/lib64/python3.3/doctest.py", line 1313, in __run
        compileflags, 1), test.globs)
      File "<doctest pyrfc3339.generator.generate[7]>", line 1
        generate(datetime(2009,01,01,12,59,59,0), accept_naive=True)
                                ^
    SyntaxError: invalid token
----------------------------------------------------------------------
File "/var/tmp/portage/dev-python/pyrfc3339-0.2/work/pyRFC3339-0.2/pyrfc3339/generator.py", line 40, in pyrfc3339.generator.generate
Failed example:
    generate(datetime(2009,01,01,12,59,59,0), accept_naive=True, utc=False)
Expected:
    Traceback (most recent call last):
    ...
    ValueError: cannot generate a local timestamp from a naive datetime
Got:
    Traceback (most recent call last):
      File "/usr/lib64/python3.3/doctest.py", line 1313, in __run
        compileflags, 1), test.globs)
      File "<doctest pyrfc3339.generator.generate[8]>", line 1
        generate(datetime(2009,01,01,12,59,59,0), accept_naive=True, utc=False)
                                ^
    SyntaxError: invalid token

>>  raise self.failureException(self.format_failure(<_io.StringIO object at 0x7fbb7b592df8>.getvalue()))
    

Name                  Stmts   Miss  Cover   Missing
---------------------------------------------------
pyrfc3339                 3      0   100%   
pyrfc3339.generator      18      5    72%   47-54
pyrfc3339.parser         24      0   100%   
pyrfc3339.utils          31      0   100%   
---------------------------------------------------
TOTAL                    76      5    93%   
----------------------------------------------------------------------
Ran 16 tests in 0.488s
```