### PR TITLE
Drop support for EOL Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "3.2"
-  - "3.3"
   - "3.4"
   - "3.5"
 # command to install dependencies


### PR DESCRIPTION
Python 2.6, 3.2 and 3.3 are EOL and no longer receiving security updates (or any updates) from the core Python team.

They're also little used.

Here's the pip installs for pyRFC3339 from PyPI for last month:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  89.38% |        189,685 |
| 3.4            |   9.54% |         20,236 |
| 3.6            |   0.68% |          1,441 |
| 3.5            |   0.33% |            701 |
| 2.6            |   0.07% |            159 |
| 3.7            |   0.00% |              3 |
| 3.3            |   0.00% |              2 |

Source: `pypinfo --start-date -59 --end-date -29 --percent --pip --markdown pyRFC3339 pyversion`