### PR TITLE
Declare support for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
+dist: xenial
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8-dev"
+matrix:
+  allow_failures:
+    - python: "3.8-dev"
 # command to install dependencies
-install:
-  - "pip install ."
+install: pip install tox-travis
 # command to run tests
-script: nosetests
+script: tox

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,9 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Internet"
         ],
 
@@ -31,5 +31,5 @@ setup(
 
     install_requires = ['pytz'],
     test_suite = 'nose.collector',
-    tests_require = ['nose']
+    tests_require = ['nose', 'coverage']
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = py27,py35,py36,py37,py38
+skip_missing_interpreters = true
+
+[testenv]
+deps =
+    coverage
+    nose
+commands =
+    nosetests


### PR DESCRIPTION
Hello,

As a software engineer, I'd like to have support for modern versions of Python declared in `setup.py` and to have corresponding tests on CI.

Also, I'd like to be able to conveniently run tests in my local environment, so I want to add a [tox](https://tox.readthedocs.io) config file.

These changes:
 - Add Python 3.7 to `setup.py`
 - Add Python 3.7 and 3.8-dev to `.travis.yml`
 - Add `tox.ini`
 - Drop support for Python 3.4 (end-of-life on [2019-03-19](https://devguide.python.org/#status-of-python-branches))