### PR TITLE
Drop pytz as a dependency on Python 3.2+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,9 +11,8 @@ Description
 pyRFC3339 parses and generates :RFC:`3339`-compliant timestamps using `Python <https://www.python.org/>`_ `datetime.datetime <https://docs.python.org/2/library/datetime.html#datetime-objects>`_ objects.
 
 >>> from pyrfc3339 import generate, parse
->>> from datetime import datetime
->>> import pytz
->>> generate(datetime.utcnow().replace(tzinfo=pytz.utc)) #doctest:+ELLIPSIS
+>>> from datetime import datetime, timezone
+>>> generate(datetime.utcnow().replace(tzinfo=timezone.utc)) #doctest:+ELLIPSIS
 '...T...Z'
 >>> parse('2009-01-01T10:01:02Z')
 datetime.datetime(2009, 1, 1, 10, 1, 2, tzinfo=<UTC>)

--- a/pyrfc3339/__init__.py
+++ b/pyrfc3339/__init__.py
@@ -3,9 +3,8 @@ pyRFC3339 parses and generates :RFC:`3339`-compliant timestamps using Python
 :class:`datetime.datetime` objects.
 
 >>> from pyrfc3339 import generate, parse
->>> from datetime import datetime
->>> import pytz
->>> generate(datetime.utcnow().replace(tzinfo=pytz.utc)) #doctest:+ELLIPSIS
+>>> from datetime import datetime, timezone
+>>> generate(datetime.utcnow().replace(tzinfo=timezone.utc)) #doctest:+ELLIPSIS
 '...T...Z'
 >>> parse('2009-01-01T10:01:02Z')
 datetime.datetime(2009, 1, 1, 10, 1, 2, tzinfo=<UTC>)

--- a/pyrfc3339/generator.py
+++ b/pyrfc3339/generator.py
@@ -1,6 +1,4 @@
-import pytz
-
-from pyrfc3339.utils import timezone, timedelta_seconds
+from pyrfc3339.utils import timezone, timedelta_seconds, utc as _utc
 
 
 def generate(dt, utc=True, accept_naive=False, microseconds=False):
@@ -8,8 +6,8 @@ def generate(dt, utc=True, accept_naive=False, microseconds=False):
     Generate an :RFC:`3339`-formatted timestamp from a
     :class:`datetime.datetime`.
 
-    >>> from datetime import datetime
-    >>> generate(datetime(2009,1,1,12,59,59,0,pytz.utc))
+    >>> from datetime import datetime, timezone
+    >>> generate(datetime(2009,1,1,12,59,59,0,timezone.utc))
     '2009-01-01T12:59:59Z'
 
     The timestamp will use UTC unless `utc=False` is specified, in which case
@@ -46,7 +44,7 @@ def generate(dt, utc=True, accept_naive=False, microseconds=False):
     if dt.tzinfo is None:
         if accept_naive is True:
             if utc is True:
-                dt = dt.replace(tzinfo=pytz.utc)
+                dt = dt.replace(tzinfo=_utc)
             else:
                 raise ValueError("cannot generate a local timestamp from " +
                                  "a naive datetime")
@@ -54,12 +52,12 @@ def generate(dt, utc=True, accept_naive=False, microseconds=False):
             raise ValueError("naive datetime and accept_naive is False")
 
     if utc is True:
-        dt = dt.astimezone(pytz.utc)
+        dt = dt.astimezone(_utc)
 
     timestamp = dt.strftime('%Y-%m-%dT%H:%M:%S')
     if microseconds is True:
         timestamp += dt.strftime('.%f')
-    if dt.tzinfo is pytz.utc:
+    if dt.tzinfo is _utc:
         timestamp += 'Z'
     else:
         timestamp += timezone(timedelta_seconds(dt.tzinfo.utcoffset(dt)))

--- a/pyrfc3339/parser.py
+++ b/pyrfc3339/parser.py
@@ -1,9 +1,7 @@
 import re
 from datetime import datetime
 
-import pytz
-
-from pyrfc3339.utils import FixedOffset
+from pyrfc3339.utils import FixedOffset, utc as _utc
 
 
 def parse(timestamp, utc=False, produce_naive=False):
@@ -12,7 +10,7 @@ def parse(timestamp, utc=False, produce_naive=False):
     `datetime.datetime`.
 
     If the timestamp is presented in UTC, then the `tzinfo` parameter of the
-    returned `datetime` will be set to `pytz.utc`.
+    returned `datetime` will be set to `datetime.timezone.utc`.
 
     >>> parse('2009-01-01T10:01:02Z')
     datetime.datetime(2009, 1, 1, 10, 1, 2, tzinfo=<UTC>)
@@ -25,7 +23,7 @@ def parse(timestamp, utc=False, produce_naive=False):
 
     However, if `parse()`  is called with `utc=True`, then the returned
     `datetime` will be normalized to UTC (and its tzinfo parameter set to
-    `pytz.utc`), regardless of the input timezone.
+    `datetime.timezone.utc`), regardless of the input timezone.
 
     >>> parse('2009-01-01T06:01:02-04:00', utc=True)
     datetime.datetime(2009, 1, 1, 10, 1, 2, tzinfo=<UTC>)
@@ -55,7 +53,7 @@ def parse(timestamp, utc=False, produce_naive=False):
             if produce_naive is True:
                 tzinfo = None
             else:
-                tzinfo = pytz.utc
+                tzinfo = _utc
         else:
             if produce_naive is True:
                 raise ValueError("cannot produce a naive datetime from " +
@@ -80,7 +78,7 @@ def parse(timestamp, utc=False, produce_naive=False):
                           tzinfo=tzinfo)
 
         if utc:
-            dt_out = dt_out.astimezone(pytz.utc)
+            dt_out = dt_out.astimezone(_utc)
 
         return dt_out
     else:

--- a/pyrfc3339/utils.py
+++ b/pyrfc3339/utils.py
@@ -3,6 +3,13 @@ from __future__ import division
 from datetime import timedelta, tzinfo
 from copy import deepcopy
 
+try:
+    from datetime import timezone as _timezone
+    utc = _timezone.utc
+except ImportError:
+    import pytz
+    utc = pytz.utc
+
 
 class FixedOffset(tzinfo):
     '''

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,16 @@
-from setuptools import setup
+from distutils.version import LooseVersion
+from setuptools import setup, __version__ as setuptools_version
 
 with open("README.rst", "r") as readme:
     long_description = readme.read()
+
+
+setuptools_known_environment_markers = (LooseVersion(setuptools_version) >= LooseVersion('36.2'))
+if setuptools_known_environment_markers:
+    install_requires = ['pytz ; python_version < "3.2"']
+else:
+    install_requires = ['pytz']
+
 
 setup(
     name = "pyRFC3339",
@@ -29,7 +38,7 @@ setup(
 
     packages = ['pyrfc3339'],
 
-    install_requires = ['pytz'],
+    install_requires = install_requires,
     test_suite = 'nose.collector',
-    tests_require = ['nose', 'coverage']
+    tests_require = ['nose', 'coverage', 'pytz']
 )


### PR DESCRIPTION
Python 3.2 introduced datetime.timezone.utc. This patch makes prefers that object, but falls back to pytz.utc if unavailable. On the packaging side the dependency is made dynamic if setuptools is new enough. Otherwise it's a hard dependency since it's likely an older installation.

I'd also be happy to drop Python 2 and simplify the patch.